### PR TITLE
Add 'shared' label on pve_storage_info

### DIFF
--- a/src/pve_exporter/collector.py
+++ b/src/pve_exporter/collector.py
@@ -202,6 +202,10 @@ class ClusterResourcesCollector(object):
                 'pve_uptime_seconds',
                 'Number of seconds since the last boot',
                 labels=['id']),
+            'shared': GaugeMetricFamily(
+                'pve_storage_shared',
+                'Whether or not the storage is shared among cluster nodes',
+                labels=['id']),
         }
 
         info_metrics = {


### PR DESCRIPTION
Hello,

This MR add a `shared` label on `pve_storage_info` metric (from https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/storage).
I missed this information to display in a separate way local storage and shared ones between nodes to avoid duplicate data in my dashboard.