### PR TITLE
Remove deprecated `test_suite` key from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
             'pve_exporter=pve_exporter.cli:main',
         ],
     },
-    test_suite="tests",
     python_requires=">=3.4",
     install_requires=[
         "prometheus_client>=0.0.11",


### PR DESCRIPTION
Fixes #72 