### PR TITLE
Add github action to build and publish docker image to github packages

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,60 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ master ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest,${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,11 +2,14 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ master ]
-    # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
+    branches: 
+      - main
+      - develop
+
   pull_request:
-    branches: [ master ]
+    branches: 
+      - main
+      - develop
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ FROM base as runtime
 COPY --from=builder /opt /opt
 
 RUN pip3 install --no-cache-dir --no-index /opt/*py3-none-any.whl && \
-    rm /opt/*py3-none-any.whl
+    rm /opt/*py3-none-any.whl && \
+    touch /etc/pve.yml
 
 USER nobody
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,10 @@ RUN pip3 wheel --no-deps /src proxmoxer==${proxmoxer_version}
 FROM base as runtime
 
 COPY --from=builder /opt /opt
+COPY pve.yml /etc/pve.yml
 
 RUN pip3 install --no-cache-dir --no-index /opt/*py3-none-any.whl && \
-    rm /opt/*py3-none-any.whl && \
-    touch /etc/pve.yml
+    rm /opt/*py3-none-any.whl 
 
 USER nobody
 

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,23 @@ Example: Run the image with a mounted configuration file and published port:
 .. code:: shell
 
    docker run --name prometheus-pve-exporter -d -p 127.0.0.1:9221:9221 -v /path/to/pve.yml:/etc/pve.yml prompve/prometheus-pve-exporter
+   
+Or use docker-compose:
+
+.. code:: yaml
+
+    version: "3.5"
+
+    services:
+      proxmox-exporter:
+        container_name: proxmox-exporter
+        image: ghcr.io/prometheus-pve/prometheus-pve-exporter
+        restart: unless-stopped
+        volumes:
+          - ./proxmox/pve.yml:/etc/pve.yml
+        ports:
+          - 127.0.0.1:9221:9221
+        
 
 Prometheus PVE Exporter will now be reachable at http://localhost:9221/.
 

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Using docker:
 
 .. code:: shell
 
-   docker pull prompve/prometheus-pve-exporter
+   docker pull ghcr.io/prometheus-pve/prometheus-pve-exporter
 
 Example: Display usage message:
 


### PR DESCRIPTION
Fixes issue #80 by automating image publishing to github packages instead of dockerhub.
Includes updates to the readme to pull from ghcr.io as well as a docker-compose example. 
