### PR TITLE
Collect io limits for ide, sata, scsi, virtio

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,8 @@ Usage
                             Exposes PVE resources info (default: True)
       --collector.config, --no-collector.config
                             Exposes PVE onboot status (default: True)
+      --collector.iolimit, --no-collector.iolimit
+                            Exposes PVE io limit (default: True)
 
 
 Use `::` for the `address` argument in order to bind to both IPv6 and IPv4

--- a/src/pve_exporter/cli.py
+++ b/src/pve_exporter/cli.py
@@ -82,6 +82,9 @@ def main():
     parser.add_argument('--collector.config', dest='collector_config',
                         action=BooleanOptionalAction, default=True,
                         help='Exposes PVE onboot status')
+    parser.add_argument('--collector.virtiolimit', dest='collector_config',
+                        action=BooleanOptionalAction, default=True,
+                        help='Exposes PVE virtiolimit')
     parser.add_argument('config', nargs='?', default='pve.yml',
                         help='Path to configuration file (pve.yml)')
     parser.add_argument('port', nargs='?', type=int, default='9221',

--- a/src/pve_exporter/cli.py
+++ b/src/pve_exporter/cli.py
@@ -82,9 +82,9 @@ def main():
     parser.add_argument('--collector.config', dest='collector_config',
                         action=BooleanOptionalAction, default=True,
                         help='Exposes PVE onboot status')
-    parser.add_argument('--collector.virtiolimit', dest='collector_config',
+    parser.add_argument('--collector.iolimit', dest='collector_iolimit',
                         action=BooleanOptionalAction, default=True,
-                        help='Exposes PVE virtiolimit')
+                        help='Exposes PVE io limit')
     parser.add_argument('config', nargs='?', default='pve.yml',
                         help='Path to configuration file (pve.yml)')
     parser.add_argument('port', nargs='?', type=int, default='9221',
@@ -100,7 +100,8 @@ def main():
         node=params.collector_node,
         cluster=params.collector_cluster,
         resources=params.collector_resources,
-        config=params.collector_config
+        config=params.collector_config,
+        iolimit=params.collector_iolimit
     )
 
     # Load configuration.


### PR DESCRIPTION
add IoLimitCollector class scrape limits settings for qemu VM
labels:
`['id', 'node', 'type', 'device', 'device_name']`
example:
```
# HELP pve_mbps_wr Proxmox vm config mbps_wr
# TYPE pve_mbps_wr gauge
pve_mbps_wr{device="virtio",device_name="virtio0",id="qemu/100",node="pve01",type="qemu"} 20.0
# HELP pve_mbps_wr_max Proxmox vm config mbps_wr_max
# TYPE pve_mbps_wr_max gauge
pve_mbps_wr_max{device="virtio",device_name="virtio0",id="qemu/100",node="pve01",type="qemu"} 25.0
# HELP pve_iops_rd Proxmox vm config iops_rd
# TYPE pve_iops_rd gauge
pve_iops_rd{device="virtio",device_name="virtio1",id="qemu/100",node="pve01",type="qemu"} 1234.0
# HELP pve_mbps_rd Proxmox vm config mbps_rd
# TYPE pve_mbps_rd gauge
pve_mbps_rd{device="virtio",device_name="virtio0",id="qemu/102",node="pve01",type="qemu"} 13.0
# HELP pve_mbps_wr Proxmox vm config mbps_wr
# TYPE pve_mbps_wr gauge
pve_mbps_wr{device="virtio",device_name="virtio0",id="qemu/102",node="pve01",type="qemu"} 17.0
```