### PR TITLE
Use gunicorn instead of the Werkzeug development server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apk update && apk upgrade
 
 RUN apk add --no-cache \
     ca-certificates \
+    py3-gunicorn \
     py3-paramiko \
     py3-pip \
     py3-prometheus-client \

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         "pyyaml",
         "requests",
         'Werkzeug',
+        'gunicorn',
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/src/pve_exporter/cli.py
+++ b/src/pve_exporter/cli.py
@@ -88,8 +88,8 @@ def main():
                         help='Port on which the exporter is listening (9221)')
     parser.add_argument('address', nargs='?', default='',
                         help='Address to which the exporter will bind')
-    parser.add_argument('--server.keyfile', help='SSL key for server')
-    parser.add_argument('--server.certfile', help='SSL certificate for server')
+    parser.add_argument('--server.keyfile', dest='server_keyfile', help='SSL key for server')
+    parser.add_argument('--server.certfile', dest='server_certfile', help='SSL certificate for server')
 
     params = parser.parse_args()
 
@@ -112,8 +112,8 @@ def main():
     gunicorn_options = {
         'bind': f'{params.address}:{params.port}',
         'threads': 2,
-        'keyfile': params.__dict__['server.keyfile'],
-        'certfile': params.__dict__['server.certfile'],
+        'keyfile': params.server_keyfile,
+        'certfile': params.server_certfile,
     }
 
     if config.valid:

--- a/src/pve_exporter/cli.py
+++ b/src/pve_exporter/cli.py
@@ -88,6 +88,8 @@ def main():
                         help='Port on which the exporter is listening (9221)')
     parser.add_argument('address', nargs='?', default='',
                         help='Address to which the exporter will bind')
+    parser.add_argument('--server.keyfile', help='SSL key for server')
+    parser.add_argument('--server.certfile', help='SSL certificate for server')
 
     params = parser.parse_args()
 
@@ -107,7 +109,14 @@ def main():
         with open(params.config) as handle:
             config = config_from_yaml(yaml.safe_load(handle))
 
+    gunicorn_options = {
+        'bind': f'{params.address}:{params.port}',
+        'threads': 2,
+        'keyfile': params.__dict__['server.keyfile'],
+        'certfile': params.__dict__['server.certfile'],
+    }
+
     if config.valid:
-        start_http_server(config, params.port, params.address, collectors)
+        start_http_server(config, gunicorn_options, collectors)
     else:
         parser.error(str(config))

--- a/src/pve_exporter/http.py
+++ b/src/pve_exporter/http.py
@@ -113,6 +113,9 @@ class PveExporterApplication:
 
 
 class StandaloneGunicornApplication(gunicorn.app.base.BaseApplication):
+    """
+    Copy-paste from https://docs.gunicorn.org/en/stable/custom.html
+    """
 
     def __init__(self, app, options=None):
         self.options = options or {}

--- a/src/pve_exporter/http.py
+++ b/src/pve_exporter/http.py
@@ -5,9 +5,9 @@ HTTP API for Proxmox VE prometheus collector.
 import logging
 import time
 
+import gunicorn.app.base
 from prometheus_client import CONTENT_TYPE_LATEST, Summary, Counter, generate_latest
 from werkzeug.routing import Map, Rule
-from werkzeug.serving import run_simple
 from werkzeug.wrappers import Request, Response
 from werkzeug.exceptions import InternalServerError
 from .collector import collect_pve
@@ -112,7 +112,24 @@ class PveExporterApplication:
         return urls.dispatch(view_func, catch_http_exceptions=True)
 
 
-def start_http_server(config, port, address, collectors):
+class StandaloneGunicornApplication(gunicorn.app.base.BaseApplication):
+
+    def __init__(self, app, options=None):
+        self.options = options or {}
+        self.application = app
+        super().__init__()
+
+    def load_config(self):
+        config = {key: value for key, value in self.options.items()
+                  if key in self.cfg.settings and value is not None}
+        for key, value in config.items():
+            self.cfg.set(key.lower(), value)
+
+    def load(self):
+        return self.application
+
+
+def start_http_server(config, gunicorn_options, collectors):
     """
     Start a HTTP API server for Proxmox VE prometheus collector.
     """
@@ -136,4 +153,4 @@ def start_http_server(config, port, address, collectors):
         duration.labels(module)
 
     app = PveExporterApplication(config, duration, errors, collectors)
-    run_simple(address, port, app, threaded=True)
+    StandaloneGunicornApplication(app, gunicorn_options).run()


### PR DESCRIPTION
Werkzeug itself doesn't recommend being used in production.

```
$ pve_exporter                                                                                                 
WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on http://:9221
Press CTRL+C to quit
```

Using Gunicorn brings in e.g. HTTPS support with low effort.

Resolves #130.