### PR TITLE
Collect disk commitment info

### DIFF
--- a/src/pve_exporter/cli.py
+++ b/src/pve_exporter/cli.py
@@ -82,6 +82,9 @@ def main():
     parser.add_argument('--collector.config', dest='collector_config',
                         action=BooleanOptionalAction, default=True,
                         help='Exposes PVE onboot status')
+    parser.add_argument('--collector.volumes', dest='collector_volumes',
+                        action=BooleanOptionalAction, default=True,
+                        help='Exposes PVE VM resource commitments')
     parser.add_argument('config', nargs='?', default='pve.yml',
                         help='Path to configuration file (pve.yml)')
     parser.add_argument('port', nargs='?', type=int, default='9221',
@@ -97,7 +100,8 @@ def main():
         node=params.collector_node,
         cluster=params.collector_cluster,
         resources=params.collector_resources,
-        config=params.collector_config
+        config=params.collector_config,
+        volumes=params.collector_volumes,
     )
 
     # Load configuration.


### PR DESCRIPTION
This is a work in progress - collect information on how much disk space one has committed to the VMs. The VM info shows only the root disk and the resources info shows only the actually used bytes - which may differ from the sum of disk size in case of thin allocation.

Unfortunately, requires `VM.Config.Disk` permission, see https://forum.proxmox.com/threads/listing-storage-content-requires-write-permissions.122211/

Added extra labels for easier grouping in Grafana.

Comments are welcome.