### PR TITLE
Publish releases with PyInstaller

### DIFF
--- a/.github/workflows/pyinstaller.yml
+++ b/.github/workflows/pyinstaller.yml
@@ -1,0 +1,20 @@
+name: PyInstaller
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project sources
+        uses: actions/checkout@v2
+
+      - name: Run release build
+        run: docker run --rm -i -v "$(pwd)":/app python:3.11-buster /app/build_release.sh ${{ github.ref_name }}
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: dist/*.tgz

--- a/build_release.sh
+++ b/build_release.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -ex
+
+TAG="${1:-SNAPSHOT}"
+
+set -u
+
+cd "$(dirname "$0")"
+
+pip3 install pyinstaller
+pip3 install -e .
+
+pyinstaller pve.spec
+
+(cd dist/ && tar -czf pve_exporter-"$TAG"-linux-i686.tgz pve_exporter/)

--- a/pve.py
+++ b/pve.py
@@ -1,0 +1,7 @@
+"""
+Entrypoint similar to what setup.py defines - but digestible for pyinstaller.
+"""
+from pve_exporter.cli import main
+
+if __name__ == '__main__':
+    main()

--- a/pve.py
+++ b/pve.py
@@ -1,7 +1,0 @@
-"""
-Entrypoint similar to what setup.py defines - but digestible for pyinstaller.
-"""
-from pve_exporter.cli import main
-
-if __name__ == '__main__':
-    main()

--- a/pve.spec
+++ b/pve.spec
@@ -5,7 +5,7 @@ block_cipher = None
 
 
 a = Analysis(
-    ['pve.py'],
+    ['src/pve_exporter/__main__.py'],
     pathex=[],
     binaries=[],
     datas=[],

--- a/pve.spec
+++ b/pve.spec
@@ -1,0 +1,50 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+block_cipher = None
+
+
+a = Analysis(
+    ['pve.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=['gunicorn.glogging', 'gunicorn.workers.gthread', 'proxmoxer.backends.https'],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='pve_exporter',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='pve_exporter',
+)

--- a/src/pve_exporter/__main__.py
+++ b/src/pve_exporter/__main__.py
@@ -1,0 +1,6 @@
+"""
+Proxmox VE exporter for the Prometheus monitoring system.
+"""
+
+from pve_exporter.cli import main
+main()


### PR DESCRIPTION
A Github action for packaging without Docker.

To use the released artifact, just extract it and run `./pve_exporter/pve_exporter /path/to/pve.yml`.

Caveats:

- Some imports may be missed by PyInstaller (specified manually in `hiddenimports` in `pve.spec`).
- Needs to be built on the oldest system that might run the release (due to GLibc compatibility). The current script builds at Debian 10 (buster) - libc6 2.28.