### PR TITLE
Add package __main__.py as an additional cli entrypoint

### DIFF
--- a/src/pve_exporter/__main__.py
+++ b/src/pve_exporter/__main__.py
@@ -1,0 +1,6 @@
+"""
+Proxmox VE exporter for the Prometheus monitoring system.
+"""
+
+from pve_exporter.cli import main
+main()


### PR DESCRIPTION
Packages can declare a cli entry point with a [__main__.py](https://docs.python.org/3/library/__main__.html#main-py-in-python-packages) file. If this file is present, a package can be executed from the command line directly using a specific python interpreter. E.g.:

```
python3 -m pve_exporter --help
```

This PR adds `src/pve_exporter/__main__.py`.