### PR TITLE
Use `local` backend if no config is provided.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     python_requires=">=3.4",
     install_requires=[
         "prometheus_client>=0.0.11",
-        "proxmoxer",
+        "proxmoxer>=1.3.0",
         "pyyaml",
         "requests",
         'Werkzeug',

--- a/src/pve_exporter/cli.py
+++ b/src/pve_exporter/cli.py
@@ -7,8 +7,7 @@ from argparse import ArgumentParser
 import os
 import yaml
 from pve_exporter.http import start_http_server
-from pve_exporter.config import config_from_yaml
-from pve_exporter.config import config_from_env
+from pve_exporter.config import config_local, config_from_yaml, config_from_env
 from pve_exporter.collector import CollectorsOptions
 
 try:
@@ -106,8 +105,11 @@ def main():
     if 'PVE_USER' in os.environ:
         config = config_from_env(os.environ)
     else:
-        with open(params.config) as handle:
-            config = config_from_yaml(yaml.safe_load(handle))
+        if os.path.isfile(params.config):
+            with open(params.config) as handle:
+                config = config_from_yaml(yaml.safe_load(handle))
+        else:
+            config = config_local()
 
     gunicorn_options = {
         'bind': f'{params.address}:{params.port}',

--- a/src/pve_exporter/collector.py
+++ b/src/pve_exporter/collector.py
@@ -313,7 +313,8 @@ class ClusterNodeConfigCollector:
 def collect_pve(config, host, options: CollectorsOptions):
     """Scrape a host and return prometheus text format for it"""
 
-    pve = ProxmoxAPI(host, **config)
+    host = [] if config.get('backend') == 'local' else [host]
+    pve = ProxmoxAPI(*host, **config)
 
     registry = CollectorRegistry()
     if options.status:

--- a/src/pve_exporter/config.py
+++ b/src/pve_exporter/config.py
@@ -37,6 +37,17 @@ def config_from_yaml(yaml):
     return ConfigMapping(modules)
 
 
+def config_local():
+    """
+    Default config for running directly on a PVE node.
+    """
+    return ConfigMapping({
+        'default': ConfigMapping({
+            'backend': 'local',
+        }),
+    })
+
+
 def config_from_env(env):
     """
     Given os.environ dictionary return a config object.


### PR DESCRIPTION
Allow running the exporter directly on Proxmox nodes, without any configuration needed.
