### PR TITLE
Collect hard disk information

### DIFF
--- a/src/pve_exporter/cli.py
+++ b/src/pve_exporter/cli.py
@@ -75,7 +75,7 @@ def main():
                         help='Exposes PVE node info')
     parser.add_argument('--collector.disk', dest='collector_disk',
                         action=BooleanOptionalAction, default=True,
-                        help='Exposes PVE node info')
+                        help='Exposes PVE disk info')
     parser.add_argument('--collector.cluster', dest='collector_cluster',
                         action=BooleanOptionalAction, default=True,
                         help='Exposes PVE cluster info')

--- a/src/pve_exporter/cli.py
+++ b/src/pve_exporter/cli.py
@@ -73,6 +73,9 @@ def main():
     parser.add_argument('--collector.node', dest='collector_node',
                         action=BooleanOptionalAction, default=True,
                         help='Exposes PVE node info')
+    parser.add_argument('--collector.disk', dest='collector_disk',
+                        action=BooleanOptionalAction, default=True,
+                        help='Exposes PVE node info')
     parser.add_argument('--collector.cluster', dest='collector_cluster',
                         action=BooleanOptionalAction, default=True,
                         help='Exposes PVE cluster info')
@@ -97,6 +100,7 @@ def main():
         status=params.collector_status,
         version=params.collector_version,
         node=params.collector_node,
+        disk=params.collector_disk,
         cluster=params.collector_cluster,
         resources=params.collector_resources,
         config=params.collector_config


### PR DESCRIPTION
This pr adds the ability to collect hard disk information.

Lables:
* serial
* health
* devpath
* size
* type
* node

Example:
```
# HELP pve_disk_info Disk info
# TYPE pve_disk_info gauge
pve_disk_info{devpath="/dev/nvme0n1",health="PASSED",node="hl-cl2",serial="S64*****",size="500107862016",type="nvme"} 1.0
pve_disk_info{devpath="/dev/sda",health="PASSED",node="hl-cl2",serial="S6P*****",size="500107862016",type="ssd"} 1.0
```

