### PR TITLE
Python -m build requires venv (wheel gets installed in venv)

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install --yes python3-build python3-wheel
+          sudo apt-get install --yes python3-build python3-venv
 
       - name: Build
         run: |


### PR DESCRIPTION
Follow-up for  #185