### PR TITLE
Refactoring: Extract cluster and node collectors into separate files

### DIFF
--- a/src/pve_exporter/collector/__init__.py
+++ b/src/pve_exporter/collector/__init__.py
@@ -1,0 +1,48 @@
+"""
+Prometheus collecters for Proxmox VE cluster.
+"""
+
+import collections
+from proxmoxer import ProxmoxAPI
+
+from prometheus_client import CollectorRegistry, generate_latest
+
+from pve_exporter.collector.cluster import (
+    StatusCollector,
+    ClusterResourcesCollector,
+    ClusterNodeCollector,
+    VersionCollector,
+    ClusterInfoCollector
+)
+from pve_exporter.collector.node import NodeConfigCollector
+
+CollectorsOptions = collections.namedtuple('CollectorsOptions', [
+    'status',
+    'version',
+    'node',
+    'cluster',
+    'resources',
+    'config',
+])
+
+
+def collect_pve(config, host, cluster, node, options: CollectorsOptions):
+    """Scrape a host and return prometheus text format for it"""
+
+    pve = ProxmoxAPI(host, **config)
+
+    registry = CollectorRegistry()
+    if cluster and options.status:
+        registry.register(StatusCollector(pve))
+    if cluster and options.resources:
+        registry.register(ClusterResourcesCollector(pve))
+    if cluster and options.node:
+        registry.register(ClusterNodeCollector(pve))
+    if cluster and options.cluster:
+        registry.register(ClusterInfoCollector(pve))
+    if cluster and options.version:
+        registry.register(VersionCollector(pve))
+    if node and options.config:
+        registry.register(NodeConfigCollector(pve))
+
+    return generate_latest(registry)

--- a/src/pve_exporter/collector/node.py
+++ b/src/pve_exporter/collector/node.py
@@ -1,0 +1,59 @@
+"""
+Prometheus collecters for Proxmox VE cluster.
+"""
+# pylint: disable=too-few-public-methods
+
+import logging
+
+from prometheus_client.core import GaugeMetricFamily
+
+
+class NodeConfigCollector:
+    """
+    Collects Proxmox VE VM information directly from config, i.e. boot, name, onboot, etc.
+    For manual test: "pvesh get /nodes/<node>/<type>/<vmid>/config"
+
+    # HELP pve_onboot_status Proxmox vm config onboot value
+    # TYPE pve_onboot_status gauge
+    pve_onboot_status{id="qemu/113",node="XXXX",type="qemu"} 1.0
+    """
+
+    def __init__(self, pve):
+        self._pve = pve
+        self._log = logging.getLogger(__name__)
+
+    def collect(self):  # pylint: disable=missing-docstring
+        metrics = {
+            'onboot': GaugeMetricFamily(
+                'pve_onboot_status',
+                'Proxmox vm config onboot value',
+                labels=['id', 'node', 'type']),
+        }
+
+        node = None
+        for entry in self._pve.cluster.status.get():
+            if entry['type'] == 'node' and entry['local']:
+                node = entry['name']
+                break
+
+        # Scrape qemu config
+        vmtype = 'qemu'
+        for vmdata in self._pve.nodes(node).qemu.get():
+            config = self._pve.nodes(node).qemu(
+                vmdata['vmid']).config.get().items()
+            for key, metric_value in config:
+                label_values = [f"{vmtype}/{vmdata['vmid']}", node, vmtype]
+                if key in metrics:
+                    metrics[key].add_metric(label_values, metric_value)
+
+        # Scrape LXC config
+        vmtype = 'lxc'
+        for vmdata in self._pve.nodes(node).lxc.get():
+            config = self._pve.nodes(node).lxc(
+                vmdata['vmid']).config.get().items()
+            for key, metric_value in config:
+                label_values = [f"{vmtype}/{vmdata['vmid']}", node, vmtype]
+                if key in metrics:
+                    metrics[key].add_metric(label_values, metric_value)
+
+        return metrics.values()

--- a/src/pve_exporter/http.py
+++ b/src/pve_exporter/http.py
@@ -10,7 +10,7 @@ from prometheus_client import CONTENT_TYPE_LATEST, Summary, Counter, generate_la
 from werkzeug.routing import Map, Rule
 from werkzeug.wrappers import Request, Response
 from werkzeug.exceptions import InternalServerError
-from .collector import collect_pve
+from pve_exporter.collector import collect_pve
 
 
 class PveExporterApplication:


### PR DESCRIPTION
In order to simplify contributions targeting `node` resources, extract node and cluster collectors into separate files.