### PR TITLE
Add ZFS replication metrics

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,10 +122,11 @@ Here's an example of the metrics exported.
 
 ::
 
-    # HELP pve_up Node/VM/CT-Status is online/running
+    # HELP pve_up Node/VM/CT/Replication-Status is online/running/enabled
     # TYPE pve_up gauge
     pve_up{id="node/proxmox"} 1.0
     pve_up{id="qemu/100"} 1.0
+    pve_up{id="replication/100-0"} 1.0
     # HELP pve_disk_size_bytes Size of storage device
     # TYPE pve_disk_size_bytes gauge
     pve_disk_size_bytes{id="qemu/100"} 6.8719476736e+010

--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,7 @@ Usage
                         [--collector.cluster | --no-collector.cluster]
                         [--collector.resources | --no-collector.resources]
                         [--collector.config | --no-collector.config]
+                        [--collector.replication | --no-collector.replication]
                         [--config.file CONFIG_FILE]
                         [--web.listen-address WEB_LISTEN_ADDRESS]
                         [--server.keyfile SERVER_KEYFILE]
@@ -90,6 +91,8 @@ Usage
 
       --collector.config, --no-collector.config
                             Exposes PVE onboot status
+      --collector.replication, --no-collector.replication
+                            Exposes PVE replication info
 
 
 Use `[::]` in the `--web.listen-address` flag in order to bind to both IPv6 and
@@ -191,6 +194,21 @@ Here's an example of the metrics exported.
     # HELP pve_version_info Proxmox VE version info
     # TYPE pve_version_info gauge
     pve_version_info{release="7.1",repoid="6fe299a0",version="7.1-5"} 1.0
+    # HELP pve_replication_duration Proxmox vm replication duration
+    # TYPE pve_replication_duration gauge
+    pve_replication_duration{guest="1",id="1-0",source="proxmox1",target="proxmox2",type="local",vmtype="qemu"} 7.73584
+    # HELP pve_replication_last_sync Proxmox vm replication last_sync
+    # TYPE pve_replication_last_sync gauge
+    pve_replication_last_sync{guest="1",id="1-0",source="proxmox1",target="proxmox2",type="local",vmtype="qemu"} 1.713382503e+09
+    # HELP pve_replication_last_try Proxmox vm replication last_try
+    # TYPE pve_replication_last_try gauge
+    pve_replication_last_try{guest="1",id="1-0",source="proxmox1",target="proxmox2",type="local",vmtype="qemu"} 1.713382503e+09
+    # HELP pve_replication_next_sync Proxmox vm replication next_sync
+    # TYPE pve_replication_next_sync gauge
+    pve_replication_next_sync{guest="1",id="1-0",source="proxmox1",target="proxmox2",type="local",vmtype="qemu"} 1.7134689e+09
+    # HELP pve_replication_fail_count Proxmox vm replication fail_count
+    # TYPE pve_replication_fail_count gauge
+    pve_replication_fail_count{guest="1",id="1-0",source="proxmox1",target="proxmox2",type="local",vmtype="qemu"} 0.0
 
 Authentication
 --------------

--- a/README.rst
+++ b/README.rst
@@ -122,11 +122,10 @@ Here's an example of the metrics exported.
 
 ::
 
-    # HELP pve_up Node/VM/CT/Replication-Status is online/running/enabled
+    # HELP pve_up Node/VM/CT-Status is online/running
     # TYPE pve_up gauge
     pve_up{id="node/proxmox"} 1.0
     pve_up{id="qemu/100"} 1.0
-    pve_up{id="replication/100-0"} 1.0
     # HELP pve_disk_size_bytes Size of storage device
     # TYPE pve_disk_size_bytes gauge
     pve_disk_size_bytes{id="qemu/100"} 6.8719476736e+010

--- a/README.rst
+++ b/README.rst
@@ -194,21 +194,24 @@ Here's an example of the metrics exported.
     # HELP pve_version_info Proxmox VE version info
     # TYPE pve_version_info gauge
     pve_version_info{release="7.1",repoid="6fe299a0",version="7.1-5"} 1.0
-    # HELP pve_replication_duration Proxmox vm replication duration
-    # TYPE pve_replication_duration gauge
-    pve_replication_duration{guest="1",id="1-0",source="proxmox1",target="proxmox2",type="local",vmtype="qemu"} 7.73584
-    # HELP pve_replication_last_sync Proxmox vm replication last_sync
-    # TYPE pve_replication_last_sync gauge
-    pve_replication_last_sync{guest="1",id="1-0",source="proxmox1",target="proxmox2",type="local",vmtype="qemu"} 1.713382503e+09
-    # HELP pve_replication_last_try Proxmox vm replication last_try
-    # TYPE pve_replication_last_try gauge
-    pve_replication_last_try{guest="1",id="1-0",source="proxmox1",target="proxmox2",type="local",vmtype="qemu"} 1.713382503e+09
-    # HELP pve_replication_next_sync Proxmox vm replication next_sync
-    # TYPE pve_replication_next_sync gauge
-    pve_replication_next_sync{guest="1",id="1-0",source="proxmox1",target="proxmox2",type="local",vmtype="qemu"} 1.7134689e+09
-    # HELP pve_replication_fail_count Proxmox vm replication fail_count
-    # TYPE pve_replication_fail_count gauge
-    pve_replication_fail_count{guest="1",id="1-0",source="proxmox1",target="proxmox2",type="local",vmtype="qemu"} 0.0
+    # HELP pve_replication_duration_seconds Proxmox vm replication duration
+    # TYPE pve_replication_duration_seconds gauge
+    pve_replication_duration_seconds{id="1-0"} 7.73584
+    # HELP pve_replication_last_sync_timestamp_seconds Proxmox vm replication last_sync
+    # TYPE pve_replication_last_sync_timestamp_seconds gauge
+    pve_replication_last_sync_timestamp_seconds{id="1-0"} 1.713382503e+09
+    # HELP pve_replication_last_try_timestamp_seconds Proxmox vm replication last_try
+    # TYPE pve_replication_last_try_timestamp_seconds gauge
+    pve_replication_last_try_timestamp_seconds{id="1-0"} 1.713382503e+09
+    # HELP pve_replication_next_sync_timestamp_seconds Proxmox vm replication next_sync
+    # TYPE pve_replication_next_sync_timestamp_seconds gauge
+    pve_replication_next_sync_timestamp_seconds{id="1-0"} 1.7134689e+09
+    # HELP pve_replication_failures_total Proxmox vm replication fail_count
+    # TYPE pve_replication_failures_total gauge
+    pve_replication_failures_total{id="1-0"} 0.0
+    # HELP pve_replication_info Proxmox vm replication info
+    # TYPE pve_replication_info gauge
+    pve_replication_info{guest="qemu/1",id="1-0",source="node/proxmox1",target="node/proxmox2",type="local"} 1.0
 
 Authentication
 --------------

--- a/README.rst
+++ b/README.rst
@@ -206,9 +206,9 @@ Here's an example of the metrics exported.
     # HELP pve_replication_next_sync_timestamp_seconds Proxmox vm replication next_sync
     # TYPE pve_replication_next_sync_timestamp_seconds gauge
     pve_replication_next_sync_timestamp_seconds{id="1-0"} 1.7134689e+09
-    # HELP pve_replication_failures_total Proxmox vm replication fail_count
-    # TYPE pve_replication_failures_total gauge
-    pve_replication_failures_total{id="1-0"} 0.0
+    # HELP pve_replication_failed_syncs Proxmox vm replication fail_count
+    # TYPE pve_replication_failed_syncs gauge
+    pve_replication_failed_syncs{id="1-0"} 0.0
     # HELP pve_replication_info Proxmox vm replication info
     # TYPE pve_replication_info gauge
     pve_replication_info{guest="qemu/1",id="1-0",source="node/proxmox1",target="node/proxmox2",type="local"} 1.0

--- a/src/pve_exporter/cli.py
+++ b/src/pve_exporter/cli.py
@@ -46,6 +46,10 @@ def main():
                            action=BooleanOptionalAction, default=True,
                            help='Exposes PVE onboot status')
 
+    nodeflags.add_argument('--collector.replication', dest='collector_replication',
+                           action=BooleanOptionalAction, default=True,
+                           help='Exposes PVE replication info')
+
     parser.add_argument('--config.file', type=pathlib.Path,
                         dest="config_file", default='/etc/prometheus/pve.yml',
                         help='Path to config file (/etc/prometheus/pve.yml)')
@@ -69,7 +73,8 @@ def main():
         node=params.collector_node,
         cluster=params.collector_cluster,
         resources=params.collector_resources,
-        config=params.collector_config
+        config=params.collector_config,
+        replication=params.collector_replication
     )
 
     # Load configuration.

--- a/src/pve_exporter/collector/__init__.py
+++ b/src/pve_exporter/collector/__init__.py
@@ -14,7 +14,10 @@ from pve_exporter.collector.cluster import (
     VersionCollector,
     ClusterInfoCollector
 )
-from pve_exporter.collector.node import NodeConfigCollector
+from pve_exporter.collector.node import (
+    NodeConfigCollector,
+    NodeReplicationCollector
+)
 
 CollectorsOptions = collections.namedtuple('CollectorsOptions', [
     'status',
@@ -23,6 +26,7 @@ CollectorsOptions = collections.namedtuple('CollectorsOptions', [
     'cluster',
     'resources',
     'config',
+    'replication'
 ])
 
 
@@ -41,8 +45,10 @@ def collect_pve(config, host, cluster, node, options: CollectorsOptions):
     if cluster and options.cluster:
         registry.register(ClusterInfoCollector(pve))
     if cluster and options.version:
-        registry.register(VersionCollector(pve))
+        registry.register(VersionCollector(pve))        
     if node and options.config:
         registry.register(NodeConfigCollector(pve))
+    if node and options.replication:
+        registry.register(NodeReplicationCollector(pve))
 
     return generate_latest(registry)

--- a/src/pve_exporter/collector/__init__.py
+++ b/src/pve_exporter/collector/__init__.py
@@ -45,7 +45,7 @@ def collect_pve(config, host, cluster, node, options: CollectorsOptions):
     if cluster and options.cluster:
         registry.register(ClusterInfoCollector(pve))
     if cluster and options.version:
-        registry.register(VersionCollector(pve))        
+        registry.register(VersionCollector(pve))
     if node and options.config:
         registry.register(NodeConfigCollector(pve))
     if node and options.replication:

--- a/src/pve_exporter/collector/cluster.py
+++ b/src/pve_exporter/collector/cluster.py
@@ -10,15 +10,14 @@ from prometheus_client.core import GaugeMetricFamily
 
 class StatusCollector:
     """
-    Collects Proxmox VE Node/VM/CT/Replication-Status
+    Collects Proxmox VE Node/VM/CT-Status
 
-    # HELP pve_up Node/VM/CT/Replication-Status is online/running/enabled
+    # HELP pve_up Node/VM/CT-Status is online/running
     # TYPE pve_up gauge
     pve_up{id="node/proxmox-host"} 1.0
     pve_up{id="cluster/pvec"} 1.0
     pve_up{id="lxc/101"} 1.0
     pve_up{id="qemu/102"} 1.0
-    pve_up{id="replication/102-0"} 1.0
     """
 
     def __init__(self, pve):
@@ -27,7 +26,7 @@ class StatusCollector:
     def collect(self):  # pylint: disable=missing-docstring
         status_metrics = GaugeMetricFamily(
             'pve_up',
-            'Node/VM/CT/Replication-Status is online/running/enabled',
+            'Node/VM/CT-Status is online/running',
             labels=['id'])
 
         for entry in self._pve.cluster.status.get():
@@ -43,13 +42,6 @@ class StatusCollector:
         for resource in self._pve.cluster.resources.get(type='vm'):
             label_values = [resource['id']]
             status_metrics.add_metric(label_values, resource['status'] == 'running')
-
-        for job in self._pve.cluster.replication.get():
-            label_values = [f"replication/{job['id']}"]
-            if 'disable' in job:
-                status_metrics.add_metric(label_values, job['disable'] == 0)
-            else:
-                status_metrics.add_metric(label_values, 1)
 
         yield status_metrics
 

--- a/src/pve_exporter/collector/node.py
+++ b/src/pve_exporter/collector/node.py
@@ -110,12 +110,7 @@ class NodeReplicationCollector:
             # Add info metric
             label_values = [str(vmdata['id']), str(vmdata['type']), f"node/{vmdata['source']}", f"node/{vmdata['target']}", f"{vmdata['vmtype']}/{vmdata['guest']}"]
 
-            # Set info metric to 0 if replication job is disabled
-            status = self._pve("nodes/{0}/replication/{1}/status".format(node,vmdata['id'])).get().get('disable')
-            if status == 1:
-                info_metrics['info'].add_metric(label_values, 0)
-            else:
-                info_metrics['info'].add_metric(label_values, 1)
+            info_metrics['info'].add_metric(label_values, 1)
 
             # Add metrics
             label_values = [str(vmdata['id'])]

--- a/src/pve_exporter/collector/node.py
+++ b/src/pve_exporter/collector/node.py
@@ -94,14 +94,16 @@ class NodeReplicationCollector:
                 labels=['id', 'type', 'vmtype', 'source', 'target', 'guest']),
         }
 
+        node = None
         for entry in self._pve.cluster.status.get():
-            if entry['type'] == 'node':
+            if entry['type'] == 'node' and entry['local']:
                 node = entry['name']
+                break
 
-                for vmdata in self._pve("nodes/{0}/replication/".format(node)).get():
-                    for key, metric_value in self._pve("nodes/{0}/replication/{1}/status".format(node,vmdata['id'])).get().items():
-                        label_values = [str(vmdata['id']), str(vmdata['type']), str(vmdata['vmtype']), str(vmdata['source']), str(vmdata['target']), str(vmdata['guest'])]
-                        if key in metrics:
-                            metrics[key].add_metric(label_values, metric_value)
+        for vmdata in self._pve("nodes/{0}/replication/".format(node)).get():
+            for key, metric_value in self._pve("nodes/{0}/replication/{1}/status".format(node,vmdata['id'])).get().items():
+                label_values = [str(vmdata['id']), str(vmdata['type']), str(vmdata['vmtype']), str(vmdata['source']), str(vmdata['target']), str(vmdata['guest'])]
+                if key in metrics:
+                    metrics[key].add_metric(label_values, metric_value)
 
         return metrics.values()

--- a/src/pve_exporter/collector/node.py
+++ b/src/pve_exporter/collector/node.py
@@ -96,7 +96,7 @@ class NodeReplicationCollector:
                 'Proxmox vm replication next_sync',
                 labels=['id']),
             'fail_count': GaugeMetricFamily(
-                'pve_replication_failures_total',
+                'pve_replication_failed_syncs',
                 'Proxmox vm replication fail_count',
                 labels=['id']),
         }

--- a/src/pve_exporter/collector/node.py
+++ b/src/pve_exporter/collector/node.py
@@ -61,7 +61,8 @@ class NodeConfigCollector:
 
 class NodeReplicationCollector:
     """
-    Collects Proxmox VE Replication information directly from status, i.e. replication duration, last_sync, last_try, next_sync, fail_count.
+    Collects Proxmox VE Replication information directly from status, i.e. replication duration,
+    last_sync, last_try, next_sync, fail_count.
     For manual test: "pvesh get /nodes/<node>/replication/<id>/status"
     """
 
@@ -106,15 +107,21 @@ class NodeReplicationCollector:
                 node = entry['name']
                 break
 
-        for vmdata in self._pve("nodes/{0}/replication/".format(node)).get():
+        for vmdata in self._pve(f"nodes/{node}/replication/").get():
             # Add info metric
-            label_values = [str(vmdata['id']), str(vmdata['type']), f"node/{vmdata['source']}", f"node/{vmdata['target']}", f"{vmdata['vmtype']}/{vmdata['guest']}"]
-
+            label_values = [
+                str(vmdata['id']),
+                str(vmdata['type']),
+                f"node/{vmdata['source']}",
+                f"node/{vmdata['target']}",
+                f"{vmdata['vmtype']}/{vmdata['guest']}",
+            ]
             info_metrics['info'].add_metric(label_values, 1)
 
             # Add metrics
             label_values = [str(vmdata['id'])]
-            for key, metric_value in self._pve("nodes/{0}/replication/{1}/status".format(node,vmdata['id'])).get().items():
+            status = self._pve(f"nodes/{node}/replication/{vmdata['id']}/status").get().items()
+            for key, metric_value in status:
                 if key in metrics:
                     metrics[key].add_metric(label_values, metric_value)
 

--- a/src/pve_exporter/collector/node.py
+++ b/src/pve_exporter/collector/node.py
@@ -107,7 +107,7 @@ class NodeReplicationCollector:
                 node = entry['name']
                 break
 
-        for vmdata in self._pve(f"nodes/{node}/replication/").get():
+        for vmdata in self._pve.nodes(node).replication.get():
             # Add info metric
             label_values = [
                 str(vmdata['id']),
@@ -120,7 +120,7 @@ class NodeReplicationCollector:
 
             # Add metrics
             label_values = [str(vmdata['id'])]
-            status = self._pve(f"nodes/{node}/replication/{vmdata['id']}/status").get()
+            status = self._pve.nodes(node).replication(vmdata['id']).status.get()
             for key, metric_value in status.items():
                 if key in metrics:
                     metrics[key].add_metric(label_values, metric_value)

--- a/src/pve_exporter/collector/node.py
+++ b/src/pve_exporter/collector/node.py
@@ -109,7 +109,13 @@ class NodeReplicationCollector:
         for vmdata in self._pve("nodes/{0}/replication/".format(node)).get():
             # Add info metric
             label_values = [str(vmdata['id']), str(vmdata['type']), f"node/{vmdata['source']}", f"node/{vmdata['target']}", f"{vmdata['vmtype']}/{vmdata['guest']}"]
-            info_metrics['info'].add_metric(label_values, 1)
+
+            # Set info metric to 0 if replication job is disabled
+            status = self._pve("nodes/{0}/replication/{1}/status".format(node,vmdata['id'])).get().get('disable')
+            if status == 1:
+                info_metrics['info'].add_metric(label_values, 0)
+            else:
+                info_metrics['info'].add_metric(label_values, 1)
 
             # Add metrics
             label_values = [str(vmdata['id'])]

--- a/src/pve_exporter/collector/node.py
+++ b/src/pve_exporter/collector/node.py
@@ -120,8 +120,8 @@ class NodeReplicationCollector:
 
             # Add metrics
             label_values = [str(vmdata['id'])]
-            status = self._pve(f"nodes/{node}/replication/{vmdata['id']}/status").get().items()
-            for key, metric_value in status:
+            status = self._pve(f"nodes/{node}/replication/{vmdata['id']}/status").get()
+            for key, metric_value in status.items():
                 if key in metrics:
                     metrics[key].add_metric(label_values, metric_value)
 

--- a/src/pve_exporter/collector/node.py
+++ b/src/pve_exporter/collector/node.py
@@ -61,11 +61,8 @@ class NodeConfigCollector:
 
 class NodeReplicationCollector:
     """
-    Collects Proxmox VE Replication information directly from status, i.e. replication time,last_time
+    Collects Proxmox VE Replication information directly from status, i.e. replication duration, last_sync, last_try, next_sync, fail_count.
     For manual test: "pvesh get /nodes/<node>/replication/<id>/status"
-    # HELP pve_replication_duration Proxmox vm replication duration
-    # TYPE pve_replication_duration gauge
-    pve_replication_duration{id="101-0",type="local", vmtype="lxc", source="server1", target="server2", guest="101"} 47.56
     """
 
     def __init__(self, pve):
@@ -82,23 +79,23 @@ class NodeReplicationCollector:
 
         metrics = {
             'duration': GaugeMetricFamily(
-                'pve_replication_duration',
+                'pve_replication_duration_seconds',
                 'Proxmox vm replication duration',
                 labels=['id']),
             'last_sync': GaugeMetricFamily(
-                'pve_replication_last_sync',
+                'pve_replication_last_sync_timestamp_seconds',
                 'Proxmox vm replication last_sync',
                 labels=['id']),
             'last_try': GaugeMetricFamily(
-                'pve_replication_last_try',
+                'pve_replication_last_try_timestamp_seconds',
                 'Proxmox vm replication last_try',
                 labels=['id']),
             'next_sync': GaugeMetricFamily(
-                'pve_replication_next_sync',
+                'pve_replication_next_sync_timestamp_seconds',
                 'Proxmox vm replication next_sync',
                 labels=['id']),
             'fail_count': GaugeMetricFamily(
-                'pve_replication_fail_count',
+                'pve_replication_failures_total',
                 'Proxmox vm replication fail_count',
                 labels=['id']),
         }

--- a/src/pve_exporter/collector/node.py
+++ b/src/pve_exporter/collector/node.py
@@ -107,20 +107,20 @@ class NodeReplicationCollector:
                 node = entry['name']
                 break
 
-        for vmdata in self._pve.nodes(node).replication.get():
+        for jobdata in self._pve.nodes(node).replication.get():
             # Add info metric
             label_values = [
-                str(vmdata['id']),
-                str(vmdata['type']),
-                f"node/{vmdata['source']}",
-                f"node/{vmdata['target']}",
-                f"{vmdata['vmtype']}/{vmdata['guest']}",
+                str(jobdata['id']),
+                str(jobdata['type']),
+                f"node/{jobdata['source']}",
+                f"node/{jobdata['target']}",
+                f"{jobdata['vmtype']}/{jobdata['guest']}",
             ]
             info_metrics['info'].add_metric(label_values, 1)
 
             # Add metrics
-            label_values = [str(vmdata['id'])]
-            status = self._pve.nodes(node).replication(vmdata['id']).status.get()
+            label_values = [str(jobdata['id'])]
+            status = self._pve.nodes(node).replication(jobdata['id']).status.get()
             for key, metric_value in status.items():
                 if key in metrics:
                     metrics[key].add_metric(label_values, metric_value)


### PR DESCRIPTION
This PR adds replication metrics as requested in issue #112.

- Replication Metrics are fetched per node
- The metrics can be enabled or disabled

I reworked the original PR #166 to the new file structure.


