### PR TITLE
Add tags label to pve_guest_info metric

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -179,7 +179,7 @@ Here's an example of the metrics exported.
     pve_storage_shared{id="storage/proxmox/vms"} 0.0
     # HELP pve_guest_info VM/CT info
     # TYPE pve_guest_info gauge
-    pve_guest_info{id="qemu/100",name="samplevm1",node="proxmox",type="qemu"} 1.0
+    pve_guest_info{id="qemu/100",name="samplevm1",node="proxmox",type="qemu",tags="tag1;tag2"} 1.0
     # HELP pve_storage_info Storage info
     # TYPE pve_storage_info gauge
     pve_storage_info{id="storage/proxmox/local",node="proxmox",storage="local"} 1.0
@@ -324,6 +324,15 @@ Example config for PVE exporter running on Prometheus host:
             target_label: instance
           - target_label: __address__
             replacement: 127.0.0.1:9221  # PVE exporter.
+
+**Note on alerting:**
+
+You can do VM tag based alerting, by using joins on ``pve_guest_info`` metric. For
+example, alerting only when VM with `critical` tag is down:
+
+.. code:: promql
+
+   (pve_guest_info{tags=~".*critical.*"} * on(id) group_left(name) pve_up{}) == 0
 
 **Note on scraping large clusters:**
 

--- a/src/pve_exporter/collector/cluster.py
+++ b/src/pve_exporter/collector/cluster.py
@@ -27,20 +27,20 @@ class StatusCollector:
         status_metrics = GaugeMetricFamily(
             'pve_up',
             'Node/VM/CT-Status is online/running',
-            labels=['id'])
+            labels=['id', 'tags'])
 
         for entry in self._pve.cluster.status.get():
             if entry['type'] == 'node':
-                label_values = [entry['id']]
+                label_values = [entry['id'], '']
                 status_metrics.add_metric(label_values, entry['online'])
             elif entry['type'] == 'cluster':
-                label_values = [f"cluster/{entry['name']}"]
+                label_values = [f"cluster/{entry['name']}", '']
                 status_metrics.add_metric(label_values, entry['quorate'])
             else:
                 raise ValueError(f"Got unexpected status entry type {entry['type']}")
 
         for resource in self._pve.cluster.resources.get(type='vm'):
-            label_values = [resource['id']]
+            label_values = [resource['id'], resource.get('tags', '')]
             status_metrics.add_metric(label_values, resource['status'] == 'running')
 
         yield status_metrics
@@ -158,47 +158,47 @@ class ClusterResourcesCollector:
             'maxdisk': GaugeMetricFamily(
                 'pve_disk_size_bytes',
                 'Size of storage device',
-                labels=['id']),
+                labels=['id', 'tags']),
             'disk': GaugeMetricFamily(
                 'pve_disk_usage_bytes',
                 'Disk usage in bytes',
-                labels=['id']),
+                labels=['id', 'tags']),
             'maxmem': GaugeMetricFamily(
                 'pve_memory_size_bytes',
                 'Size of memory',
-                labels=['id']),
+                labels=['id', 'tags']),
             'mem': GaugeMetricFamily(
                 'pve_memory_usage_bytes',
                 'Memory usage in bytes',
-                labels=['id']),
+                labels=['id', 'tags']),
             'netout': GaugeMetricFamily(
                 'pve_network_transmit_bytes',
                 'Number of bytes transmitted over the network',
-                labels=['id']),
+                labels=['id', 'tags']),
             'netin': GaugeMetricFamily(
                 'pve_network_receive_bytes',
                 'Number of bytes received over the network',
-                labels=['id']),
+                labels=['id', 'tags']),
             'diskwrite': GaugeMetricFamily(
                 'pve_disk_write_bytes',
                 'Number of bytes written to storage',
-                labels=['id']),
+                labels=['id', 'tags']),
             'diskread': GaugeMetricFamily(
                 'pve_disk_read_bytes',
                 'Number of bytes read from storage',
-                labels=['id']),
+                labels=['id', 'tags']),
             'cpu': GaugeMetricFamily(
                 'pve_cpu_usage_ratio',
                 'CPU usage (value between 0.0 and pve_cpu_usage_limit)',
-                labels=['id']),
+                labels=['id', 'tags']),
             'maxcpu': GaugeMetricFamily(
                 'pve_cpu_usage_limit',
                 'Maximum allowed CPU usage',
-                labels=['id']),
+                labels=['id', 'tags']),
             'uptime': GaugeMetricFamily(
                 'pve_uptime_seconds',
                 'Number of seconds since the last boot',
-                labels=['id']),
+                labels=['id', 'tags']),
             'shared': GaugeMetricFamily(
                 'pve_storage_shared',
                 'Whether or not the storage is shared among cluster nodes',
@@ -209,7 +209,7 @@ class ClusterResourcesCollector:
             'guest': GaugeMetricFamily(
                 'pve_guest_info',
                 'VM/CT info',
-                labels=['id', 'node', 'name', 'type', 'template']),
+                labels=['id', 'node', 'name', 'type', 'template', 'tags']),
             'storage': GaugeMetricFamily(
                 'pve_storage_info',
                 'Storage info',
@@ -218,15 +218,15 @@ class ClusterResourcesCollector:
 
         info_lookup = {
             'lxc': {
-                'labels': ['id', 'node', 'name', 'type', 'template'],
+                'labels': ['id', 'node', 'name', 'type', 'template', 'tags'],
                 'gauge': info_metrics['guest'],
             },
             'qemu': {
-                'labels': ['id', 'node', 'name', 'type', 'template'],
+                'labels': ['id', 'node', 'name', 'type', 'template', 'tags'],
                 'gauge': info_metrics['guest'],
             },
             'storage': {
-                'labels': ['id', 'node', 'storage'],
+                'labels': ['id', 'node', 'storage', 'tags'],
                 'gauge': info_metrics['storage'],
             },
         }
@@ -239,7 +239,7 @@ class ClusterResourcesCollector:
                 label_values = [str(resource.get(key, '')) for key in labels]
                 info_lookup[restype]['gauge'].add_metric(label_values, 1)
 
-            label_values = [resource['id']]
+            label_values = [resource['id'], resource.get('tags', '')]
             for key, metric_value in resource.items():
                 if key in metrics:
                     metrics[key].add_metric(label_values, metric_value)

--- a/src/pve_exporter/collector/cluster.py
+++ b/src/pve_exporter/collector/cluster.py
@@ -27,20 +27,20 @@ class StatusCollector:
         status_metrics = GaugeMetricFamily(
             'pve_up',
             'Node/VM/CT-Status is online/running',
-            labels=['id', 'tags'])
+            labels=['id'])
 
         for entry in self._pve.cluster.status.get():
             if entry['type'] == 'node':
-                label_values = [entry['id'], '']
+                label_values = [entry['id']]
                 status_metrics.add_metric(label_values, entry['online'])
             elif entry['type'] == 'cluster':
-                label_values = [f"cluster/{entry['name']}", '']
+                label_values = [f"cluster/{entry['name']}"]
                 status_metrics.add_metric(label_values, entry['quorate'])
             else:
                 raise ValueError(f"Got unexpected status entry type {entry['type']}")
 
         for resource in self._pve.cluster.resources.get(type='vm'):
-            label_values = [resource['id'], resource.get('tags', '')]
+            label_values = [resource['id']]
             status_metrics.add_metric(label_values, resource['status'] == 'running')
 
         yield status_metrics
@@ -158,47 +158,47 @@ class ClusterResourcesCollector:
             'maxdisk': GaugeMetricFamily(
                 'pve_disk_size_bytes',
                 'Size of storage device',
-                labels=['id', 'tags']),
+                labels=['id']),
             'disk': GaugeMetricFamily(
                 'pve_disk_usage_bytes',
                 'Disk usage in bytes',
-                labels=['id', 'tags']),
+                labels=['id']),
             'maxmem': GaugeMetricFamily(
                 'pve_memory_size_bytes',
                 'Size of memory',
-                labels=['id', 'tags']),
+                labels=['id']),
             'mem': GaugeMetricFamily(
                 'pve_memory_usage_bytes',
                 'Memory usage in bytes',
-                labels=['id', 'tags']),
+                labels=['id']),
             'netout': GaugeMetricFamily(
                 'pve_network_transmit_bytes',
                 'Number of bytes transmitted over the network',
-                labels=['id', 'tags']),
+                labels=['id']),
             'netin': GaugeMetricFamily(
                 'pve_network_receive_bytes',
                 'Number of bytes received over the network',
-                labels=['id', 'tags']),
+                labels=['id']),
             'diskwrite': GaugeMetricFamily(
                 'pve_disk_write_bytes',
                 'Number of bytes written to storage',
-                labels=['id', 'tags']),
+                labels=['id']),
             'diskread': GaugeMetricFamily(
                 'pve_disk_read_bytes',
                 'Number of bytes read from storage',
-                labels=['id', 'tags']),
+                labels=['id']),
             'cpu': GaugeMetricFamily(
                 'pve_cpu_usage_ratio',
                 'CPU usage (value between 0.0 and pve_cpu_usage_limit)',
-                labels=['id', 'tags']),
+                labels=['id']),
             'maxcpu': GaugeMetricFamily(
                 'pve_cpu_usage_limit',
                 'Maximum allowed CPU usage',
-                labels=['id', 'tags']),
+                labels=['id']),
             'uptime': GaugeMetricFamily(
                 'pve_uptime_seconds',
                 'Number of seconds since the last boot',
-                labels=['id', 'tags']),
+                labels=['id']),
             'shared': GaugeMetricFamily(
                 'pve_storage_shared',
                 'Whether or not the storage is shared among cluster nodes',
@@ -226,7 +226,7 @@ class ClusterResourcesCollector:
                 'gauge': info_metrics['guest'],
             },
             'storage': {
-                'labels': ['id', 'node', 'storage', 'tags'],
+                'labels': ['id', 'node', 'storage'],
                 'gauge': info_metrics['storage'],
             },
         }
@@ -239,7 +239,7 @@ class ClusterResourcesCollector:
                 label_values = [str(resource.get(key, '')) for key in labels]
                 info_lookup[restype]['gauge'].add_metric(label_values, 1)
 
-            label_values = [resource['id'], resource.get('tags', '')]
+            label_values = [resource['id']]
             for key, metric_value in resource.items():
                 if key in metrics:
                     metrics[key].add_metric(label_values, metric_value)


### PR DESCRIPTION
Recent proxmox versions introduced tags for VMs. These provide useful for metrics as well, especially for configuring alerts i.e. something like `pve_up{tags=~".*important.*"} == 0`. 

This PR adds tags to all metrics related to the VMs. Since `.resource.get` is used everywhere, this change should be backwards compatible.