### PR TITLE
ZFS pool metrics

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -223,15 +223,15 @@ Here's an example of the metrics exported.
     # HELP pve_zfs_health_status Proxmox ZFS health status
     # TYPE pve_zfs_health_status gauge
     pve_zfs_health_status{id="node/proxmox",name="pool1"} 1.0
-    # HELP pve_zfs_total_size_bytes Proxmox ZFS total size in bytes
-    # TYPE pve_zfs_total_size_bytes gauge
-    pve_zfs_total_size_bytes{id="node/proxmox",name="pool1"} 1.906965479424e+012
+    # HELP pve_zfs_size_bytes Proxmox ZFS total size in bytes
+    # TYPE pve_zfs_size_bytes gauge
+    pve_zfs_size_bytes{id="node/proxmox",name="pool1"} 1.906965479424e+012
     # HELP pve_zfs_fragmentation_percentage Proxmox ZFS fragmentation percentage
     # TYPE pve_zfs_fragmentation_percentage gauge
     pve_zfs_fragmentation_percentage{id="node/proxmox",name="pool1"} 13.0
-    # HELP pve_zfs_allocated_space_bytes Proxmox ZFS allocated space in bytes
-    # TYPE pve_zfs_allocated_space_bytes gauge
-    pve_zfs_allocated_space_bytes{id="node/proxmox",name="pool1"} 2.42927853568e+011
+    # HELP pve_zfs_allocated_bytes Proxmox ZFS allocated space in bytes
+    # TYPE pve_zfs_allocated_bytes gauge
+    pve_zfs_allocated_bytes{id="node/proxmox",name="pool1"} 2.42927853568e+011
 
 Authentication
 --------------

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,7 @@ Usage
                         [--collector.resources | --no-collector.resources]
                         [--collector.config | --no-collector.config]
                         [--collector.replication | --no-collector.replication]
+                        [--collector.zfs | --no-collector.zfs]
                         [--config.file CONFIG_FILE]
                         [--web.listen-address WEB_LISTEN_ADDRESS]
                         [--server.keyfile SERVER_KEYFILE]
@@ -93,7 +94,8 @@ Usage
                             Exposes PVE onboot status
       --collector.replication, --no-collector.replication
                             Exposes PVE replication info
-
+      --collector.zfs, --no-collector.zfs
+                            Exposes PVE ZFS info
 
 Use `[::]` in the `--web.listen-address` flag in order to bind to both IPv6 and
 IPv4 sockets on dual stacked machines.
@@ -212,6 +214,24 @@ Here's an example of the metrics exported.
     # HELP pve_replication_info Proxmox vm replication info
     # TYPE pve_replication_info gauge
     pve_replication_info{guest="qemu/1",id="1-0",source="node/proxmox1",target="node/proxmox2",type="local"} 1.0
+    # HELP pve_zfs_free_bytes Proxmox ZFS free space in bytes
+    # TYPE pve_zfs_free_bytes gauge
+    pve_zfs_free_bytes{id="node/proxmox",name="pool1"} 1.664037625856e+012
+    # HELP pve_zfs_deduplication_ratio Proxmox ZFS deduplication ratio
+    # TYPE pve_zfs_deduplication_ratio gauge
+    pve_zfs_deduplication_ratio{id="node/proxmox",name="pool1"} 1.0
+    # HELP pve_zfs_health_status Proxmox ZFS health status
+    # TYPE pve_zfs_health_status gauge
+    pve_zfs_health_status{id="node/proxmox",name="pool1"} 1.0
+    # HELP pve_zfs_total_size_bytes Proxmox ZFS total size in bytes
+    # TYPE pve_zfs_total_size_bytes gauge
+    pve_zfs_total_size_bytes{id="node/proxmox",name="pool1"} 1.906965479424e+012
+    # HELP pve_zfs_fragmentation_percentage Proxmox ZFS fragmentation percentage
+    # TYPE pve_zfs_fragmentation_percentage gauge
+    pve_zfs_fragmentation_percentage{id="node/proxmox",name="pool1"} 13.0
+    # HELP pve_zfs_allocated_space_bytes Proxmox ZFS allocated space in bytes
+    # TYPE pve_zfs_allocated_space_bytes gauge
+    pve_zfs_allocated_space_bytes{id="node/proxmox",name="pool1"} 2.42927853568e+011
 
 Authentication
 --------------

--- a/src/pve_exporter/cli.py
+++ b/src/pve_exporter/cli.py
@@ -50,6 +50,10 @@ def main():
                            action=BooleanOptionalAction, default=True,
                            help='Exposes PVE replication info')
 
+    nodeflags.add_argument('--collector.zfs', dest='collector_zfs',
+                           action=BooleanOptionalAction, default=True,
+                           help='Exposes PVE ZFS info')
+
     parser.add_argument('--config.file', type=pathlib.Path,
                         dest="config_file", default='/etc/prometheus/pve.yml',
                         help='Path to config file (/etc/prometheus/pve.yml)')
@@ -74,7 +78,8 @@ def main():
         cluster=params.collector_cluster,
         resources=params.collector_resources,
         config=params.collector_config,
-        replication=params.collector_replication
+        replication=params.collector_replication,
+        zfs=params.collector_zfs
     )
 
     # Load configuration.

--- a/src/pve_exporter/collector/__init__.py
+++ b/src/pve_exporter/collector/__init__.py
@@ -16,7 +16,8 @@ from pve_exporter.collector.cluster import (
 )
 from pve_exporter.collector.node import (
     NodeConfigCollector,
-    NodeReplicationCollector
+    NodeReplicationCollector,
+    NodeZFSCollector
 )
 
 CollectorsOptions = collections.namedtuple('CollectorsOptions', [
@@ -26,7 +27,8 @@ CollectorsOptions = collections.namedtuple('CollectorsOptions', [
     'cluster',
     'resources',
     'config',
-    'replication'
+    'replication',
+    'zfs'
 ])
 
 
@@ -50,5 +52,7 @@ def collect_pve(config, host, cluster, node, options: CollectorsOptions):
         registry.register(NodeConfigCollector(pve))
     if node and options.replication:
         registry.register(NodeReplicationCollector(pve))
+    if node and options.zfs:
+        registry.register(NodeZFSCollector(pve))
 
     return generate_latest(registry)

--- a/src/pve_exporter/collector/node.py
+++ b/src/pve_exporter/collector/node.py
@@ -180,7 +180,7 @@ class NodeZFSCollector:
                         if metric_value == 'ONLINE':
                             metric_value = 1
                         else:
-                            metric_value = 0 
+                            metric_value = 0
 
                     metrics[key].add_metric(label_values, metric_value)
 

--- a/src/pve_exporter/collector/node.py
+++ b/src/pve_exporter/collector/node.py
@@ -126,3 +126,62 @@ class NodeReplicationCollector:
                     metrics[key].add_metric(label_values, metric_value)
 
         return itertools.chain(metrics.values(), info_metrics.values())
+
+class NodeZFSCollector:
+    """
+    Collects Proxmox VE ZFS information such as name, errors, state.
+    For manual test: "pvesh get /nodes/{node}/disks/zfs/{name}"
+    """
+
+    def __init__(self, pve):
+        self._pve = pve
+
+    def collect(self): # pylint: disable=missing-docstring
+
+        metrics = {
+            'free': GaugeMetricFamily(
+                'pve_zfs_free_bytes',
+                'Proxmox ZFS free space in bytes',
+                labels=['name', 'id']),
+            'dedup': GaugeMetricFamily(
+                'pve_zfs_deduplication_ratio',
+                'Proxmox ZFS deduplication ratio',
+                labels=['name', 'id']),
+            'health': GaugeMetricFamily(
+                'pve_zfs_health_status',
+                'Proxmox ZFS health status',
+                labels=['name', 'id']),
+            'size': GaugeMetricFamily(
+                'pve_zfs_total_size_bytes',
+                'Proxmox ZFS total size in bytes',
+                labels=['name', 'id']),
+            'frag': GaugeMetricFamily(
+                'pve_zfs_fragmentation_percentage',
+                'Proxmox ZFS fragmentation percentage',
+                labels=['name', 'id']),
+            'alloc': GaugeMetricFamily(
+                'pve_zfs_allocated_space_bytes',
+                'Proxmox ZFS allocated space in bytes',
+                labels=['name', 'id']),
+        }
+
+        node = None
+        for entry in self._pve.cluster.status.get():
+            if entry['type'] == 'node' and entry['local']:
+                node = entry['name']
+                break
+
+        for zfsdata in self._pve.nodes(node).disks.zfs.get():
+            for key, metric_value in zfsdata.items():
+                label_values = [zfsdata['name'], f"node/{node}"]
+                if key in metrics:
+                    if key == 'health':
+                        # Convert ONLINE to 1 and other states to 0
+                        if metric_value == 'ONLINE':
+                            metric_value = 1
+                        else:
+                            metric_value = 0 
+
+                    metrics[key].add_metric(label_values, metric_value)
+
+        return metrics.values()

--- a/src/pve_exporter/collector/node.py
+++ b/src/pve_exporter/collector/node.py
@@ -129,8 +129,8 @@ class NodeReplicationCollector:
 
 class NodeZFSCollector:
     """
-    Collects Proxmox VE ZFS information such as name, errors, state.
-    For manual test: "pvesh get /nodes/{node}/disks/zfs/{name}"
+    Collects Proxmox VE ZFS information such as name, size, health, free, dedup, frag, alloc.
+    For manual test: "pvesh get /nodes/<node>/disks/zfs"
     """
 
     def __init__(self, pve):
@@ -152,16 +152,16 @@ class NodeZFSCollector:
                 'Proxmox ZFS health status',
                 labels=['name', 'id']),
             'size': GaugeMetricFamily(
-                'pve_zfs_total_size_bytes',
-                'Proxmox ZFS total size in bytes',
+                'pve_zfs_size_bytes',
+                'Proxmox ZFS size in bytes',
                 labels=['name', 'id']),
             'frag': GaugeMetricFamily(
                 'pve_zfs_fragmentation_percentage',
                 'Proxmox ZFS fragmentation percentage',
                 labels=['name', 'id']),
             'alloc': GaugeMetricFamily(
-                'pve_zfs_allocated_space_bytes',
-                'Proxmox ZFS allocated space in bytes',
+                'pve_zfs_allocated_bytes',
+                'Proxmox ZFS allocated in bytes',
                 labels=['name', 'id']),
         }
 


### PR DESCRIPTION
This PR adds ZFS metrics at a pool level.
The metrics contain node name and pool name, as a ZFS pool does not have a unique ID accross a PVE cluster.

Proxmox API path: `/api2/json/nodes/{node}/disks/zfs`

Example return data of API call:
```
{
    "data": [
        {
            "name": "rpool",
            "size": 1906965479424,
            "health": "ONLINE",
            "free": 1585176993792,
            "dedup": 1,
            "frag": 21,
            "alloc": 321788485632
        }
    ]
}
```