### PR TITLE
Added documentation about using a custom CA with Docker

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -271,6 +271,24 @@ to the credentials. Note that PVE `supports Let's Encrypt`_ out ouf the box. In
 many cases setting up trusted certificates is the better option than operating
 with self-signed certs.
 
+**Note on using Docker with a custom CA:**
+
+When operating PVE with certificates signed by a custom Certificate Authority
+(or a public CA certificate that is not yet included in the Docker image), and
+the easiest way is to import the certificate into the local trust store of the
+host (see this `SE answer`_ for Debian/Ubuntu) then bind mount the host's
+ca-certificates.crt file, and set the ``REQUESTS_CA_BUNDLE`` enviroment variable
+in Docker to use the CA bundle (otherwise the exporter will ignore it).
+
+Docker Compose snippet:
+
+.. code:: yaml
+
+    volumes:
+      - '/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro'
+    environment:
+      - REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
 Proxmox VE Configuration
 ------------------------
 


### PR DESCRIPTION
Our company is using custom CA infrastructure, and I faced the problem of either disable tls_verify or somehow use our CA certificates.
We also had newer certificates that were signed by Sectigo, which are included in the default public CA certificates, but not in the Docker image, since it uses something from 2023.
I tried to open a feature request https://github.com/prometheus-pve/prometheus-pve-exporter/issues/264, but it was not successful, so I went on figuring out how to do this.
Turns out the suggestions did not work, as the Docker image ignores the bind mounted certificate store, and you also have to set a variable for Python so the exporter actually uses the file.
Since I spent quite much time trying to figure this all out, I thought it will be useful for other people to include my findings in the documentation.