### PR TITLE
build: add ghcr.io as registry

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -12,6 +12,9 @@ jobs:
 
     permissions:
       contents: read
+      packages: write
+      attestations: write
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -27,7 +30,9 @@ jobs:
         uses: docker/metadata-action@v5
         id: meta
         with:
-          images: prompve/prometheus-pve-exporter
+          images: |
+            prompve/prometheus-pve-exporter
+            ghcr.io/${{ github.repository }}
           tags: |
             type=pep440,pattern={{version}}
             type=pep440,pattern={{major}}.{{minor}}
@@ -39,6 +44,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -47,3 +59,10 @@ jobs:
           platforms: linux/arm64,linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
Add ghcr.io as second registry to allow fallback in case dockerhub is unavailable. Furhter artifact attestation was added:

"Artifact attestations enable you to increase the supply chain security of your builds by establishing where and how your software was built."