### PR TITLE
Fix GHA workflow failing on artifact attestation

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
+        id: push
         with:
           context: .
           push: true


### PR DESCRIPTION
The `id` step is missing from the workflow, causing the [`subject-digest` field](https://github.com/prometheus-pve/prometheus-pve-exporter/blob/main/.github/workflows/container-image.yml#L67) on the attestation step to be null. This resulted in the [v3.5.3 release workflow](https://github.com/prometheus-pve/prometheus-pve-exporter/actions/runs/14513815846) failing.

@znerol when you review this PR, would you mind making the new GHCR image [here](https://github.com/orgs/prometheus-pve/packages) public? Its visibility has to be manually updated now that the first image has been pushed. This should be a one-off change.