### PR TITLE
Improve Error Exeption on Connectivity/Auth issues

### DIFF
--- a/src/pve_exporter/http.py
+++ b/src/pve_exporter/http.py
@@ -8,6 +8,7 @@ from functools import partial
 
 import gunicorn.app.base
 import requests.exceptions
+from proxmoxer.core import ResourceException, AuthenticationError
 from prometheus_client import CONTENT_TYPE_LATEST, Summary, Counter, generate_latest
 from werkzeug.routing import Map, Rule
 from werkzeug.wrappers import Request, Response
@@ -118,6 +119,10 @@ class PveExporterApplication:
             return view_registry[endpoint](**params)
         except requests.exceptions.ConnectionError as error:
             self._log.warning("Connection failed for '%s': %s", params.get('target', 'localhost'), error)
+            self._errors.labels(args.get('module', 'default')).inc()
+            raise InternalServerError from error
+        except (ResourceException, AuthenticationError) as error:
+            self._log.warning("PVE API error for '%s': %s", params.get('target', 'localhost'), error)
             self._errors.labels(args.get('module', 'default')).inc()
             raise InternalServerError from error
         except Exception as error:  # pylint: disable=broad-except

--- a/src/pve_exporter/http.py
+++ b/src/pve_exporter/http.py
@@ -7,6 +7,7 @@ import time
 from functools import partial
 
 import gunicorn.app.base
+import requests.exceptions
 from prometheus_client import CONTENT_TYPE_LATEST, Summary, Counter, generate_latest
 from werkzeug.routing import Map, Rule
 from werkzeug.wrappers import Request, Response
@@ -115,6 +116,10 @@ class PveExporterApplication:
 
         try:
             return view_registry[endpoint](**params)
+        except requests.exceptions.ConnectionError as error:
+            self._log.warning("Connection failed for '%s': %s", params.get('target', 'localhost'), error)
+            self._errors.labels(args.get('module', 'default')).inc()
+            raise InternalServerError from error
         except Exception as error:  # pylint: disable=broad-except
             self._log.exception("Exception thrown while rendering view")
             self._errors.labels(args.get('module', 'default')).inc()


### PR DESCRIPTION

These four errors are not probbably catched and causing (with traceback) over 40 lines of log output in the container, which is not ideal. We should catch these and log them as warnings instead.

these are caused by 1) Auth issues, 2) Routing/IPv6 Stack down,3) SSL cert issues or 4) simple Host down. 
```
proxmoxer.core.ResourceException: 401 Unauthorized: Authentication failed! - {'errors': b''}
prometheus-pve-exporter  | requests.exceptions.ConnectionError: HTTPSConnectionPool(host='pve1.example.com', port=8006): Max retries exceeded with url: /api2/json/access/ticket (Caused by NewConnectionError("HTTPSConnection(host='pve1.example.com', port=8006): Failed to establish a new connection: [Errno 101] Network unreachable"))
prometheus-pve-exporter  | urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='pve1.example.com', port=8006): Max retries exceeded with url: /api2/json/access/ticket (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1010)')))
prometheus-pve-exporter  | requests.exceptions.ConnectionError: HTTPSConnectionPool(host='pve2.example.com', port=8006): Max retries exceeded with url: /api2/json/access/ticket (Caused by NewConnectionError("HTTPSConnection(host='pve2.example.com', port=8006): Failed to establish a new connection: [Errno 113] Host is unreachable"))
```

This PR aims to catch these specific errors and log them tidy as one line warnings

Thanks 