### PR TITLE
Add QEMU guest agent filesystem collector

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,7 @@ Usage
                         [--collector.config | --no-collector.config]
                         [--collector.replication | --no-collector.replication]
                         [--collector.subscription | --no-collector.subscription]
+                        [--collector.qga-fs | --no-collector.qga-fs]
                         [--collector.pve-api-metrics | --no-collector.pve-api-metrics]
                         [--collector.target-metrics | --no-collector.target-metrics]
                         [--config.file CONFIG_FILE]
@@ -118,6 +119,8 @@ Usage
                             Exposes PVE replication info
       --collector.subscription, --no-collector.subscription
                             Exposes PVE subscription info
+      --collector.qga-fs, --no-collector.qga-fs
+                            Exposes VM filesystem usage via QEMU guest agent
 
     scrape collectors:
       metrics concerning the operation of the Prometheus PVE exporter itself.
@@ -145,6 +148,11 @@ collectors.
 Note that that the config collector results in one API call per guest VM/CT.
 It is therefore recommended to disable this collector using the
 `--no-collector.config` flag on big deployments.
+
+Note that the ``qga-fs`` collector results in one additional API call per
+running QEMU guest. It is therefore recommended to disable this collector
+using the ``--no-collector.qga-fs`` flag on large deployments. Requires
+``qemu-guest-agent`` installed and enabled inside each VM.
 
 Scrape collectors return metrics concerning the operation of the Prometheus PVE
 exporter itself. Those metrics are available from the `/metric`.
@@ -319,7 +327,13 @@ Here's an example of the metrics exported.
     # HELP pve_replication_info Proxmox vm replication info
     # TYPE pve_replication_info gauge
     pve_replication_info{guest="qemu/1",id="1-0",source="node/proxmox1",target="node/proxmox2",type="local"} 1.0
-
+    # HELP pve_qga_fs_used_bytes Guest filesystem used bytes (via QEMU guest agent)
+    # TYPE pve_qga_fs_used_bytes gauge
+    pve_qga_fs_used_bytes{disk="/dev/sda5",fstype="ext4",id="qemu/100",mountpoint="/",name="samplevm1",node="proxmox"} 1.038385152e+010
+    # HELP pve_qga_fs_size_bytes Guest filesystem total bytes (via QEMU guest agent)
+    # TYPE pve_qga_fs_size_bytes gauge
+    pve_qga_fs_size_bytes{disk="/dev/sda5",fstype="ext4",id="qemu/100",mountpoint="/",name="samplevm1",node="proxmox"} 6.8719476736e+010
+    
 Authentication
 --------------
 

--- a/src/pve_exporter/cli.py
+++ b/src/pve_exporter/cli.py
@@ -60,6 +60,9 @@ def main():
     nodeflags.add_argument('--collector.subscription', dest='collector_subscription',
                               action=BooleanOptionalAction, default=True,
                               help='Exposes PVE subscription info')
+    nodeflags.add_argument('--collector.qga-fs', dest='collector_qga_fs',
+                           action=BooleanOptionalAction, default=False,
+                           help='Exposes VM filesystem usage via QEMU guest agent')
 
     scrapeflags = parser.add_argument_group('scrape collectors', description=(
         'metrics concerning the operation of the Prometheus PVE exporter itself.'
@@ -98,7 +101,8 @@ def main():
         backup_info=params.collector_backup_info,
         config=params.collector_config,
         replication=params.collector_replication,
-        qdevice=params.collector_qdevice
+        qdevice=params.collector_qdevice,
+        qga_fs=params.collector_qga_fs
     )
     scrape_metrics.API_METRICS_ENABLED = params.api_metrics_enabled
     scrape_metrics.TARGET_METRICS_ENABLED = params.target_metrics_enabled

--- a/src/pve_exporter/collector/__init__.py
+++ b/src/pve_exporter/collector/__init__.py
@@ -19,7 +19,8 @@ from pve_exporter.collector.cluster import (
 from pve_exporter.collector.node import (
     NodeConfigCollector,
     NodeReplicationCollector,
-    SubscriptionCollector
+    SubscriptionCollector,
+    QgaFsCollector
 )
 
 CollectorsOptions = collections.namedtuple('CollectorsOptions', [
@@ -32,7 +33,8 @@ CollectorsOptions = collections.namedtuple('CollectorsOptions', [
     'backup_info',
     'config',
     'replication',
-    'qdevice'
+    'qdevice',
+    'qga_fs'
 ])
 
 
@@ -62,5 +64,7 @@ def collect_pve(config, host, cluster, node, options: CollectorsOptions):
         registry.register(NodeConfigCollector(pve))
     if node and options.replication:
         registry.register(NodeReplicationCollector(pve))
+    if node and options.qga_fs:
+        registry.register(QgaFsCollector(pve))
 
     return generate_latest(registry)

--- a/src/pve_exporter/collector/node.py
+++ b/src/pve_exporter/collector/node.py
@@ -188,3 +188,75 @@ class SubscriptionCollector:
         yield info_metric
         yield status_metric
         yield next_due_metric
+
+class QgaFsCollector:
+    """
+    Collects guest filesystem usage via QEMU Guest Agent get-fsinfo.
+
+    # HELP pve_qga_fs_used_bytes Guest filesystem used bytes (via QEMU guest agent)
+    # TYPE pve_qga_fs_used_bytes gauge
+    # HELP pve_qga_fs_size_bytes Guest filesystem total bytes (via QEMU guest agent)
+    # TYPE pve_qga_fs_size_bytes gauge
+    """
+
+    SKIP_FSTYPES = frozenset(['tmpfs', 'devtmpfs', 'squashfs', 'overlay', 'sysfs', 'proc'])
+
+    def __init__(self, pve):
+        self._pve = pve
+
+    def _collect_vm(self, node, vmdata, used_metric, size_metric):
+        """Collect filesystem metrics for a single VM via QEMU guest agent."""
+        vmid = vmdata['vmid']
+        name = vmdata.get('name', str(vmid))
+
+        if vmdata.get('status') != 'running':
+            return
+
+        try:
+            config = self._pve.nodes(node).qemu(vmid).config.get()
+            if not str(config.get('agent', '0')).startswith('1'):
+                return
+        except Exception:  # pylint: disable=broad-except
+            return
+
+        try:
+            result = self._pve.nodes(node).qemu(vmid).agent('get-fsinfo').get()
+            for fs in result.get('result', []):
+                if fs.get('type', '') in self.SKIP_FSTYPES:
+                    continue
+                labels = [
+                    f'qemu/{vmid}', node, name,
+                    fs.get('mountpoint', ''),
+                    fs.get('type', ''),
+                    (fs.get('disk') or [{}])[0].get('dev', ''),
+                ]
+                used_metric.add_metric(labels, fs.get('used-bytes', 0))
+                size_metric.add_metric(labels, fs.get('total-bytes', 0))
+        except Exception:  # pylint: disable=broad-except
+            pass
+
+    def collect(self):  # pylint: disable=missing-docstring
+        used_metric = GaugeMetricFamily(
+            'pve_qga_fs_used_bytes',
+            'Guest filesystem used bytes (via QEMU guest agent)',
+            labels=['id', 'node', 'name', 'mountpoint', 'fstype', 'disk'])
+
+        size_metric = GaugeMetricFamily(
+            'pve_qga_fs_size_bytes',
+            'Guest filesystem total bytes (via QEMU guest agent)',
+            labels=['id', 'node', 'name', 'mountpoint', 'fstype', 'disk'])
+
+        node = None
+        for entry in self._pve.cluster.status.get():
+            if entry['type'] == 'node' and entry['local']:
+                node = entry['name']
+                break
+
+        if node is None:
+            return
+
+        for vmdata in self._pve.nodes(node).qemu.get():
+            self._collect_vm(node, vmdata, used_metric, size_metric)
+
+        yield used_metric
+        yield size_metric


### PR DESCRIPTION
Closes #77

## Summary

Adds an optional node collector `QgaFsCollector` that exposes per-VM
filesystem usage by querying the QEMU Guest Agent `get-fsinfo` endpoint.

This addresses the long-standing issue where `pve_disk_usage_bytes` always
returns `0` for QEMU VMs, since the Proxmox cluster resources API does not
populate the `disk` field for QEMU guests.

## New metrics
pve_qga_fs_used_bytes{id, node, name, mountpoint, fstype, disk}
pve_qga_fs_size_bytes{id, node, name, mountpoint, fstype, disk}


## Behaviour

- Disabled by default (`--no-collector.qga-fs`)
- Skips VMs that are not running
- Skips VMs without `agent` enabled in config
- Silently skips VMs where the agent is not responding
- Skips pseudo filesystems (tmpfs, devtmpfs, squashfs, overlay, sysfs, proc)
- Implemented as a node collector per maintainer guidance in #381